### PR TITLE
fix: Pass options to socket.io, handle connect_error event

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "socketio-test-client",
   "private": false,
-  "version": "0.3.3",
+  "version": "0.3.4",
   "type": "module",
   "author": {
     "name": "Seraj aldin Haqiqi",

--- a/src/lib/handlers/socketio.ts
+++ b/src/lib/handlers/socketio.ts
@@ -30,6 +30,10 @@ export const toggleConnection = () => {
         serverSettings.set({...server, status: 'connected',id: socket.id});
         logger('connected');
       });
+      socket.on('connect_error', error => {
+        serverSettings.set({...server, status: 'disconnected', id:undefined})
+        logger('connection error: ' + error.message);
+      })
       socket.on("disconnect", () => {
         serverSettings.set({...server, status: 'disconnected', id:undefined})
         logger('disconnected');

--- a/src/lib/handlers/socketio.ts
+++ b/src/lib/handlers/socketio.ts
@@ -23,8 +23,7 @@ export const toggleConnection = () => {
       serverSettings.set({...server, status: 'connecting'})
       logger('connecting');
 
-      socket = io(address);
-      console.log({options})
+      socket = io(address, options);
       socket.connect();
       
       socket.on("connect", () => {


### PR DESCRIPTION
You forgot to pass the options object to socket.io  
Also the `connect_error` event was not handled so the status would get stuck on `connecting` if the connection was rejected by the server for any reason.

This PR fixes that.

related:
- #4